### PR TITLE
Updating transformHit to fix broken autocomplete

### DIFF
--- a/js/algoliasearch/internals/frontend/common.js
+++ b/js/algoliasearch/internals/frontend/common.js
@@ -60,6 +60,8 @@ document.addEventListener("DOMContentLoaded", function (e) {
 		};
 		
 		window.transformHit = function (hit, price_key, helper) {
+			hit._highlightResult = hit._highlightResult || {};
+			
 			if (Array.isArray(hit.categories)) {
 				hit.categories = hit.categories.join(', ');
 			}


### PR DESCRIPTION
**Summary**

Updating js/algoliasearch/internals/frontend/common.js to short circuit hit._highlightResult in the window.transformHit function

This is to fix an issue experienced where the Autocomplete dropdown stops showing products because this property is null

**Result**

This means hit._highlightResult is never null